### PR TITLE
Fade in on page load now stays within white area

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -111,7 +111,7 @@ inputs {
 
 @-webkit-keyframes animatebottom {
     from {
-        bottom: -100px;
+        bottom: -30px;
         opacity: 0
     }
     to {
@@ -122,7 +122,7 @@ inputs {
 
 @keyframes animatebottom {
     from {
-        bottom: -100px;
+        bottom: -30px;
         opacity: 0
     }
     to {


### PR DESCRIPTION
Beforehand, the whole element was loading outside of a div and therefore was overriding any z-indexing when it faded into the div.